### PR TITLE
Show other tabs in devtools

### DIFF
--- a/src/components/sections/home/overboard-story/devtools/index.tsx
+++ b/src/components/sections/home/overboard-story/devtools/index.tsx
@@ -32,9 +32,9 @@ function ElementSelectorIcon() {
 
 export const tabs = {
   console: Console,
+  react: ReactDevTools,
   elements: Elements,
-  network: Network,
-  react: ReactDevTools
+  network: Network
 }
 
 export function TabNav({

--- a/src/components/sections/home/overboard-story/scrollytelling.tsx
+++ b/src/components/sections/home/overboard-story/scrollytelling.tsx
@@ -252,7 +252,12 @@ const headerHeight = 50
 const timelineHeight = 90
 const printMarkers: ProgressMarker[] = [{ position: 50 }]
 const storeId = 'hero'
-const devtoolsTabs: (keyof typeof tabs)[] = ['console', 'react']
+const devtoolsTabs: (keyof typeof tabs)[] = [
+  'console',
+  'react',
+  'elements',
+  'network'
+]
 
 const SCROLLYTELLING_PX_DURATION = 16000
 


### PR DESCRIPTION
Small detail, but i think it'd be nice to show the Elements and Network monitor in the devtools as well even though they are inert.

### New
<img width="1405" alt="Screen Shot 2022-09-11 at 9 46 54 PM" src="https://user-images.githubusercontent.com/254562/189575804-1595d1ac-7636-4de1-802b-2f0ada14f6e2.png">

### Old
<img width="1430" alt="Screen Shot 2022-09-11 at 9 46 04 PM" src="https://user-images.githubusercontent.com/254562/189575702-de1f0342-7589-4af1-8f77-3bee3c2bd2a8.png">
