### PR TITLE
Fix pricing card's typeform button

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-switch": "^0.1.5",
     "@radix-ui/react-tabs": "^1.0.0",
     "@replayio/overboard": "^0.4.1",
+    "@typeform/embed-react": "^2.22.0",
     "clsx": "1.1.1",
     "embla-carousel-react": "^8.0.0-rc05",
     "global": "^4.4.0",

--- a/src/components/sections/pricing/hero/card/index.tsx
+++ b/src/components/sections/pricing/hero/card/index.tsx
@@ -1,3 +1,4 @@
+import { PopupButton } from '@typeform/embed-react'
 import clsx from 'clsx'
 import { FC } from 'react'
 
@@ -52,16 +53,14 @@ export const Card: FC<Props> = ({ mode, data }) => {
           {data.cta}
         </ButtonLink>
       ) : (
-        <Button
-          variant={data.type === 'Pro' ? 'tertiary' : 'primary'}
-          className={s.cta}
-          data-tf-popup="jTudlerL"
-          data-tf-iframe-props="title=Test Suites"
-          data-tf-medium="snippet"
-          aria-label="Learn more about Test Suites"
-        >
-          {data.cta}
-        </Button>
+        <PopupButton id="jTudlerL" className={s.cta}>
+          <Button
+            variant={data.type === 'Pro' ? 'tertiary' : 'primary'}
+            aria-label="Learn more about Test Suites"
+          >
+            {data.cta}
+          </Button>
+        </PopupButton>
       )}
 
       <ul>

--- a/src/components/sections/pricing/plans/index.tsx
+++ b/src/components/sections/pricing/plans/index.tsx
@@ -1,3 +1,4 @@
+import { PopupButton } from '@typeform/embed-react'
 import clsx from 'clsx'
 import Image from 'next/image'
 import { FC, useEffect, useRef, useState } from 'react'
@@ -378,16 +379,14 @@ export const Plans: FC<{ selectedTab: string }> = ({ selectedTab }) => {
                     {plan.cta}
                   </ButtonLink>
                 ) : (
-                  <Button
-                    className={s.cta}
-                    data-tf-popup="jTudlerL"
-                    data-tf-iframe-props="title=Test Suites"
-                    data-tf-medium="snippet"
-                    aria-label="Learn more about Test Suites"
-                    variant="tertiary-inverted-alt"
-                  >
-                    {plan.cta}
-                  </Button>
+                  <PopupButton id="jTudlerL" className={s.cta}>
+                    <Button
+                      variant="tertiary-inverted-alt"
+                      aria-label="Learn more about Test Suites"
+                    >
+                      {plan.cta}
+                    </Button>
+                  </PopupButton>
                 )}{' '}
               </div>
               <div>

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -42,7 +42,7 @@ const Pricing = () => {
             Bug Reporting
           </TabsPrimitive.Trigger>
           <TabsPrimitive.Trigger value="tests" className={styles.tab}>
-            Testsuites
+            Test Suites
           </TabsPrimitive.Trigger>
         </TabsPrimitive.List>
       </TabsPrimitive.Root>

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,6 +803,19 @@
   dependencies:
     tslib "^2.4.0"
 
+"@typeform/embed-react@^2.22.0":
+  version "2.22.0"
+  resolved "https://registry.yarnpkg.com/@typeform/embed-react/-/embed-react-2.22.0.tgz#ceaf82c883279ca586c7a833f7954594f48df522"
+  integrity sha512-X1VIURICIgqtEncwqJ5lRM6Tv2V07jqIjFrjF+jnawu6aiAUtzE1GcTRgJ8BdNc4WBVtopegkTCnAq5nNZnnPw==
+  dependencies:
+    "@typeform/embed" "2.12.0"
+    fast-deep-equal "^3.1.3"
+
+"@typeform/embed@2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@typeform/embed/-/embed-2.12.0.tgz#b3a4c98c868871d1c641e43446c60d667a432e13"
+  integrity sha512-IhnmTix38LQ3dxW7a5WPWkAGznYD2f8KZCjqc8Q80yFHmt+igQMhosEsdQkl9uPmxzuXryzLXJKEtOhc3p6wkg==
+
 "@types/css-font-loading-module@0.0.7":
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz#2f98ede46acc0975de85c0b7b0ebe06041d24601"


### PR DESCRIPTION
The typeform buttons were not being rendered on the first pass. So the typeform script doesn't attached the event listeners to it correctly.

This uses typeform's [react library](https://www.typeform.com/developers/embed/react/) to take care of that for us.
