### PR TITLE
Don't render download buttons on server

### DIFF
--- a/src/components/common/download-button/index.tsx
+++ b/src/components/common/download-button/index.tsx
@@ -42,6 +42,10 @@ export const DownloadButton: React.FC<Partial<ButtonLinkProps>> = ({
   children,
   ...rest
 }) => {
+  if (isServer) {
+    return null
+  }
+
   const platform = availablePlatforms[getPlatform()]
   const PlatformIcon = platform.icon
 
@@ -63,6 +67,10 @@ export const DownloadLink: React.FC<Partial<NavLinkProps>> = ({
   children,
   ...rest
 }) => {
+  if (isServer) {
+    return null
+  }
+
   const platform = availablePlatforms[getPlatform()]
   const PlatformIcon = platform.icon
 


### PR DESCRIPTION
This PR:

- Updates  the download buttons to not render on the server, to avoid falsely advertising Mac download links when the page loads for Windows/Linux users