### PR TITLE
Add umami event tracking for download events

### DIFF
--- a/src/components/common/download-button/index.tsx
+++ b/src/components/common/download-button/index.tsx
@@ -70,6 +70,9 @@ export const DownloadButton: React.FC<Partial<ButtonLinkProps>> = ({
       href={platformIcon.downloadSource}
       target="_blank"
       download
+      onClick={() =>
+        (window as any).umami?.track(`hero download click (${platform})`)
+      }
     >
       {children}
 
@@ -100,6 +103,9 @@ export const DownloadLink: React.FC<Partial<NavLinkProps>> = ({
       href={platformIcon.downloadSource}
       target="_blank"
       download
+      onClick={() =>
+        (window as any).umami?.track(`nav download click (${platform})`)
+      }
     >
       {children}
 


### PR DESCRIPTION
This uses Umami to [track events](https://umami.is/docs/track-events).

Runbook: https://www.notion.so/replayio/Using-website-analytics-Umami-453f1cdc363a48c493f5bb3a840c11e9