### PR TITLE
Fix deploy

### DIFF
--- a/src/components/sections/time-travel/overboard-story/debugger/index.tsx
+++ b/src/components/sections/time-travel/overboard-story/debugger/index.tsx
@@ -182,7 +182,7 @@ export const Debugger = forwardRef<HTMLDivElement, DebuggerProps>(
 
       Object.entries(snapshot.variables).map(([key, value]) => {
         if (value === '^') {
-          snapshot.variables[key] = pathInfo?.prev.variables[key]
+          snapshot.variables[key] = pathInfo?.prev?.variables[key]
         }
       })
 


### PR DESCRIPTION
Fix failing deploy on 
```
Type error: 'pathInfo.prev' is possibly 'undefined'.
  183 |       Object.entries(snapshot.variables).map(([key, value]) => {
  184 |         if (value === '^') {
> 185 |           snapshot.variables[key] = pathInfo?.prev.variables[key]
      |                                     ^
  186 |         }
  187 |       })
  188 | 
error: script "build" exited with code 1 (SIGHUP)
Error: Command "bun run build" exited with 1
```