### PR TITLE
Copy updates

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,8 @@
   },
   "[less]": {
     "editor.formatOnSave": false
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   }
 }

--- a/src/components/common/meta.tsx
+++ b/src/components/common/meta.tsx
@@ -124,6 +124,7 @@ export const Meta = (props: MetaProps) => {
 
         <link rel="canonical" href={resolvedMetadata.canonical} />
 
+        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
         <script src="//embed.typeform.com/next/embed.js" />
 
         {props.preload?.map(({ href, as }) => (

--- a/src/components/layout/footer/index.tsx
+++ b/src/components/layout/footer/index.tsx
@@ -44,7 +44,7 @@ export const Footer = () => {
             sizes={getImageSizes(2, 2, 2)}
           />
         </div>
-        <h2 className={s.title}>Start Replaying now</h2>
+        <h2 className={s.title}>Start replaying now</h2>
       </div>
 
       <div className={s.mainContent}>

--- a/src/components/sections/homepage/bugs-slider/bugs-slider.module.scss
+++ b/src/components/sections/homepage/bugs-slider/bugs-slider.module.scss
@@ -117,7 +117,7 @@
           }
 
           .infoSide {
-            padding: 36px 0;
+            padding: 18px 0 36px;
             display: flex;
             flex-direction: column;
             justify-content: space-between;
@@ -126,9 +126,14 @@
               padding: 0;
             }
 
+            .header {
+              font-size: 10px;
+              line-height: 4em;
+            }
+
             .title {
-              font-size: 18px;
-              line-height: 32px;
+              font-size: 16px;
+              line-height: 26px;
               letter-spacing: -0.02em;
 
               @include respond-to('tablet-lg') {
@@ -776,6 +781,29 @@
   100% {
     transform: translate(0, 14px) scale(1);
     filter: brightness(0.5);
+  }
+}
+
+.featureList {
+  margin-top: 20px;
+
+  li {
+    font-size: 14px;
+    line-height: 26px;
+    color: var(--grey-400);
+    filter: brightness(0.9);
+    list-style-type: disc;
+
+    &:hover {
+      // text-decoration: underline;
+      cursor: pointer;
+      filter: brightness(1);
+
+      &::after {
+        content: '➔';
+        margin-left: 5px;
+      }
+    }
   }
 }
 

--- a/src/components/sections/homepage/bugs-slider/bugs-slider.module.scss
+++ b/src/components/sections/homepage/bugs-slider/bugs-slider.module.scss
@@ -22,13 +22,13 @@
     margin-top: 72px;
 
     @include respond-to('min-tablet-lg') {
-      mask-image: linear-gradient(
-        to left,
-        rgb(0 0 0 / 0) 0,
-        var(--white),
-        var(--white),
-        rgb(0 0 0 / 0) 100%
-      );
+      // mask-image: linear-gradient(
+      //   to left,
+      //   rgb(0 0 0 / 0) 0,
+      //   var(--white),
+      //   var(--white),
+      //   rgb(0 0 0 / 0) 100%
+      // );
     }
 
     @include respond-to('tablet-lg') {

--- a/src/components/sections/homepage/bugs-slider/index.tsx
+++ b/src/components/sections/homepage/bugs-slider/index.tsx
@@ -60,40 +60,26 @@ export const BugsSlider = () => {
     >
       <TitleAndSubtitle
         className={s.titleAndSubtitle}
-        title={{ children: 'Freeze bugs in time.', as: 'h2' }}
+        title={{ children: 'Stop reproducing bugs', as: 'h2' }}
         subtitle={{
           children: (
-            <span>
-              <b>Hate reproducing issues?</b> Replay is a new kind of browser
-              that's able to record and deterministically replay web
-              applications so that you only need to capture bugs once.
-            </span>
+            <>
+              <span>
+                Say goodbye to screenshots, videos, and repro steps. Recording a
+                bug with Replay lets anyone debug it as if they were there when
+                it happened.
+              </span>{' '}
+              <Link
+                style={{ textDecoration: 'underline' }}
+                href="https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76?pvs=4#0f7aa30ac9e548bfb6e5329da12acc50"
+                aria-label="Create a team"
+              >
+                Learn More
+              </Link>
+            </>
           )
         }}
       />
-
-      <div className={s.embla} ref={emblaRef}>
-        <div className={s.emblaContainer}>
-          {data.map((item, index) => (
-            <div
-              key={item.id}
-              className={clsx(s.emblaSlide, {
-                [s.active as string]: index === currentSlide
-              })}
-            >
-              <div
-                className={s.card}
-                onPointerEnter={() => setInteracting(true)}
-                onPointerLeave={() => setInteracting(false)}
-              >
-                <InfoSide isTablet={Boolean(isTablet)} {...item} />
-
-                {!isTablet && <item.Asset />}
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
 
       <div className={s.ctasWrapper}>
         <ButtonTimer
@@ -131,13 +117,38 @@ export const BugsSlider = () => {
           Test suites
         </ButtonTimer>
       </div>
+
+      <div className={s.embla} ref={emblaRef}>
+        <div className={s.emblaContainer}>
+          {data.map((item, index) => (
+            <div
+              key={item.id}
+              className={clsx(s.emblaSlide, {
+                [s.active as string]: index === currentSlide
+              })}
+            >
+              <div
+                className={s.card}
+                onPointerEnter={() => setInteracting(true)}
+                onPointerLeave={() => setInteracting(false)}
+              >
+                <InfoSide isTablet={Boolean(isTablet)} {...item} />
+
+                {!isTablet && <item.Asset />}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
     </Section>
   )
 }
 
 const InfoSide = ({
   isTablet,
+  header,
   title,
+  body,
   Asset,
   description,
   cta,
@@ -146,7 +157,11 @@ const InfoSide = ({
 }: DataType & { isTablet: boolean }) => {
   return (
     <div className={s.infoSide}>
-      <p className={s.title}>{title}</p>
+      <div>
+        <span className={s.header}>{header}</span>
+        <p className={s.title}>{title}</p>
+        <div>{body}</div>
+      </div>
 
       {isTablet && <Asset />}
 
@@ -544,7 +559,9 @@ const AssetSideComment: React.FC<AssetSideCommentProps> = ({
 
 type DataType = {
   id: number
+  header: string
   title: ReactNode
+  body: ReactNode
   description: ReactNode
   Asset: React.FC
   cta: {
@@ -558,28 +575,28 @@ type DataType = {
 const data: DataType[] = [
   {
     id: 0,
+    header: 'File the perfect bug report.'.toUpperCase(),
     title: (
       <>
-        Getting replays in your bug reports is like getting a video{' '}
         <span>
-          that you can inspect with Browser DevTools and debug with print
-          statements.
+          Bugs reported with Replay are fully actionable and quickly understood
+          by developers. Never close issues again for a lack of information.
         </span>
       </>
     ),
+    body: <></>,
     description: (
       <>
-        Want to get bug reports with replays?
         <br />
         <Link href="https://app.replay.io/team/new" aria-label="Create a team">
           Create a team
         </Link>{' '}
-        and start a free 30 day trial.
+        and start sharing replays with your team.
       </>
     ),
     Asset: AssetSideBugs,
     cta: {
-      href: 'https://docs.replay.io/bug-reports',
+      href: 'https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76?pvs=4#0e1c031fd5004dc58c4bf9256226a0c9',
       label: 'Bug reports'
     },
     videoPoster:
@@ -589,18 +606,36 @@ const data: DataType[] = [
   },
   {
     id: 1,
+    header: 'Fix all your Flaky Tests.'.toUpperCase(),
     title: (
       <>
-        Recording your browser tests in CI{' '}
         <span>
-          lets you find and fix the timing issues in your application that are
-          causing your tests to be flaky.
+          Stop wasting time looking at failures you can’t figure out, or
+          suppressing tests because they don’t pass reliably.
         </span>
       </>
     ),
+    body: (<div>
+      <ul className={s.featureList}>
+        <li>
+          <Link href="https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76?pvs=4#eebc67a3047148b0a293d6e2182ff0bc">
+            Deploy with confidence
+          </Link>{' '}
+        </li>
+        <li>
+          <Link href="https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76?pvs=4#93a08392f81b4bf08b82c028a93eae6f">
+            Debug failures remotely
+          </Link>{' '}
+        </li>
+        <li>
+          <Link href="https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76?pvs=4#bff7da3bfc7b4a44958e09692df9ee6d">
+            Modernize your Test Suite
+          </Link>{' '}
+        </li>
+      </ul>
+    </div>),
     description: (
       <>
-        Want green test runs that finish quickly?{' '}
         <button
           className={s.waitlist}
           data-tf-popup="jTudlerL"
@@ -608,14 +643,14 @@ const data: DataType[] = [
           data-tf-medium="snippet"
           aria-label="Learn more about Test Suites"
         >
-          Join our waitlist
+          Get in touch
         </button>{' '}
-        and start fixing your tests.
+        to start recording your test suite.
       </>
     ),
     Asset: AssetSideBrowser,
     cta: {
-      href: 'https://docs.replay.io/test-suites',
+      href: 'https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76?pvs=4#5f861bb962aa40e5a9365e6c78391435',
       label: 'Test suites'
     },
     videoPoster:

--- a/src/components/sections/homepage/debug-with-friends/index.tsx
+++ b/src/components/sections/homepage/debug-with-friends/index.tsx
@@ -143,7 +143,9 @@ export const DebugWithFriends = () => {
             subtitle={{
               children: (
                 <span>
-                  Replay DevTools has modern collaboration features that make it easier to share context, integrate with tools, and squash bugs as a team.
+                  Replay DevTools has modern collaboration features that make it
+                  easier to share context, integrate with tools, and squash bugs
+                  as a team.
                 </span>
               )
             }}

--- a/src/components/sections/homepage/developer-tools/index.tsx
+++ b/src/components/sections/homepage/developer-tools/index.tsx
@@ -535,14 +535,16 @@ export const DeveloperTools = () => {
         <TitleAndSubtitle
           title={{
             as: 'h2',
-            children: 'Next Gen Browser DevTools.'
+            children: 'Zero in on the root cause.'
           }}
           subtitle={{
             children: (
               <span>
-                <b>Built on top of our Time Travel Protocol</b>, Replay DevTools is the debugging experience you've always wanted, but never believed was possible.
+                Replay DevTools is the debugging experience you've always
+                wanted, but never believed was possible. Trace any problem
+                directly back to its root cause, no matter how complex or timing
+                sensitive.{' '}
               </span>
-
             )
           }}
         />

--- a/src/components/sections/homepage/features/index.tsx
+++ b/src/components/sections/homepage/features/index.tsx
@@ -85,7 +85,7 @@ export const Features = () => {
           className={s.titleAndSubtitle}
           title={{
             as: 'h2',
-            children: 'Enterprise ready'
+            children: 'Enterprise grade'
           }}
           subtitle={{
             children: (

--- a/src/components/sections/homepage/hero/hero.module.scss
+++ b/src/components/sections/homepage/hero/hero.module.scss
@@ -89,8 +89,8 @@
     }
 
     .subtitle {
-      font-size: 18px;
-      max-width: 400px;
+      font-size: 17px;
+      max-width: 600px;
       line-height: 24px;
     }
 

--- a/src/components/sections/homepage/hero/index.tsx
+++ b/src/components/sections/homepage/hero/index.tsx
@@ -3,7 +3,8 @@ import { gsap } from 'lib/gsap'
 import dynamic, { LoaderComponent } from 'next/dynamic'
 import Image from 'next/image'
 import Link from 'next/link'
-import { Ref, useEffect, useRef } from 'react'
+import { useRouter } from 'next/router'
+import { Ref, useEffect, useMemo, useRef } from 'react'
 import { useIntercom } from 'react-use-intercom'
 
 import { AspectBox } from '~/components/common/aspect-box'
@@ -69,6 +70,29 @@ const outlineSvgSize = {
   height: 876
 }
 
+const subheroes = [
+  <span key="variant-4">
+    Replay is the only browser that lets you record and retroactively debug your
+    application. Fix the hardest issues as a team and take control of your
+    support process and test suite.
+  </span>,
+  <span key="variant-3">
+    Replay is the only browser that lets you record and retroactively debug your
+    application with <b>print statements</b> and <b>Browser DevTools</b> so that
+    you can file the perfect bug report and fix failing flaky tests.
+  </span>,
+
+  <span key="variant-2">
+    Replay is the only browser that lets you record, retroactively debug, and
+    fix the hardest issues as a team with perfect reproducibility.
+  </span>,
+
+  <span key="variant-1">
+    Replay is the only browser that lets you record and retroactively debug your
+    application with <b>print statements</b> and <b>Browser DevTools</b>.
+  </span>
+]
+
 export const Hero = () => {
   const { boot } = useIntercom()
   const firstRef = useRef<HTMLDivElement>(null)
@@ -76,6 +100,14 @@ export const Hero = () => {
 
   const { isDesktop } = useDeviceDetect()
   const isSm = useMedia('(max-width: 768px)')
+  const router = useRouter()
+
+  const subhero = useMemo(() => {
+    const variant = router.query.variant
+      ? parseInt(router.query.variant as string)
+      : 0
+    return subheroes[variant]
+  }, [router.query])
 
   useEffect(() => {
     if (!isDesktop) return
@@ -374,16 +406,18 @@ export const Hero = () => {
             }}
             subtitle={{
               className: s.subtitle,
-              children: (
-                <span>
-                  Record and retroactively debug your application with{' '}
-                  <b>print statements</b> and <b>Browser DevTools</b>.
-                </span>
-              )
+              children: subhero
             }}
           />
 
           <div className={s['ctas']}>
+            <DownloadButton
+              mode="primary"
+              size="big"
+              aria-label="Download Replay"
+            >
+              Download Replay
+            </DownloadButton>
             <Video.Modal
               poster="/images/homepage/hero-video-placeholder.png"
               url="https://stream.mux.com/RfpT026NiAnQTWXP4BKsBBUHjFReABrAO01ltzQxmOVQE.m3u8"
@@ -394,13 +428,6 @@ export const Hero = () => {
                 </Button>
               </Video.Trigger>
             </Video.Modal>
-            <DownloadButton
-              mode="primary"
-              size="big"
-              aria-label="Download Replay"
-            >
-              Download Replay
-            </DownloadButton>
           </div>
         </Container>
       </div>

--- a/src/components/sections/homepage/org-testimonials/index.tsx
+++ b/src/components/sections/homepage/org-testimonials/index.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx'
 import useEmblaCarousel, { EmblaCarouselType } from 'embla-carousel-react'
 import { gsap } from 'lib/gsap'
 import Image from 'next/image'
+import Link from 'next/link'
 import { useEffect, useRef, useState } from 'react'
 
 import { NextIcon } from '~/components/icons/next'
@@ -10,6 +11,7 @@ import { SolidIcon } from '~/components/icons/solid'
 import { Container } from '~/components/layout/container'
 import { Section } from '~/components/layout/section'
 import { RadioButtons } from '~/components/primitives/radio-buttons'
+import { TitleAndSubtitle } from '~/components/primitives/texts'
 import { useGsapTime } from '~/hooks/use-gsap-time'
 import { useIntersectionObserver } from '~/hooks/use-intersection-observer'
 import { useIsomorphicLayoutEffect } from '~/hooks/use-isomorphic-layout-effect'
@@ -132,6 +134,28 @@ export const OrganizationTestimonials = () => {
 
   return (
     <Section id="homepage-organization-testimonials" className={s['section']}>
+      <TitleAndSubtitle
+        className={s.titleAndSubtitle}
+        title={{ children: 'Travel back in time', as: 'h2' }}
+        subtitle={{
+          children: (
+            <>
+              <span>
+                Replay is a next generation time travel debugger. The browser
+                records just enough so that you can retroactively inspect your
+                application.
+              </span>{' '}
+              <Link
+                style={{ textDecoration: 'underline' }}
+                href="https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76?pvs=4#dd66af0c13694f2e9f8ccadbb19258c1"
+                aria-label="Time travel debugging"
+              >
+                Learn More
+              </Link>
+            </>
+          )
+        }}
+      />
       <Container className={s['container']}>
         <div className={clsx(s['root'])} ref={inViewRef}>
           <div className={clsx(s['embla'], s['organizations-wrapper'])}>

--- a/src/components/sections/homepage/org-testimonials/org-testimonials.module.scss
+++ b/src/components/sections/homepage/org-testimonials/org-testimonials.module.scss
@@ -15,6 +15,10 @@
   }
 }
 
+.titleAndSubtitle {
+  margin-bottom: 60px;
+}
+
 .root {
   overflow: hidden;
   padding: 40px 0;


### PR DESCRIPTION
This incorporates the copy changes in #161 into the existing layout. The goal of these changes was to find something that was easy to land. Both the copy and the layout can be improved, but I think this is a step in the right direction.

### Changes

1. **The H2 is one line** which is slightly more readable. 

<img width="1038" alt="Screenshot 2023-10-13 at 1 57 39 PM" src="https://github.com/replayio/landing-page/assets/254562/fefa57a0-6f80-4511-bb9a-72069c1f0d6a">


3. **Travel back in time** is above the time travelers testimonials so there is better spacing between the time travel debugging and the stop reproducing section.. 
<img width="1227" alt="Screenshot 2023-10-13 at 1 57 21 PM" src="https://github.com/replayio/landing-page/assets/254562/9c58a8ed-0da9-4554-89fa-d395961a84b8">


4. The **Bug Reports** and **Test Suites** badges were moved up so that they're below the H2 and it is harder to miss the test suites section.
<img width="717" alt="Screenshot 2023-10-13 at 1 56 51 PM" src="https://github.com/replayio/landing-page/assets/254562/090e7d40-22c1-49fd-9cb0-20ece1ed7601">

5. **The test suites sub sections are linked to the docs** so that they're more accessible without asking the user to read too much text.

<img width="518" alt="Screenshot 2023-10-13 at 1 56 43 PM" src="https://github.com/replayio/landing-page/assets/254562/50e4286c-5ab0-476d-8d2f-4e0234c49db4">

6. **There are now [learn more](https://www.notion.so/replayio/Replay-io-Overview-05d8d8ae2a9045b682c19a1ae2de9f76#dd66af0c13694f2e9f8ccadbb19258c1) links** in a couple of sections that link to a new docs page which we'll need to update and publish before this goes live.

<img width="717" alt="Screenshot 2023-10-13 at 1 56 51 PM" src="https://github.com/replayio/landing-page/assets/254562/090e7d40-22c1-49fd-9cb0-20ece1ed7601">

