### PR TITLE
Point replay.io to a new video

### DIFF
--- a/src/components/sections/homepage/hero/index.tsx
+++ b/src/components/sections/homepage/hero/index.tsx
@@ -205,7 +205,7 @@ export const Hero = () => {
 
   const videoDetails = {
     1: {
-      playbackId: 'QkSFKUrsBI00NzaCuiUelsPsekl6miPCDfC102qLvNxK4',
+      playbackId: 'Depao01zs006N01sxcX5CNkt007q6gbF3YvGLPT01wZrz27k',
       muted: true,
       poster: ''
     },
@@ -604,7 +604,7 @@ export const Hero = () => {
               }}
               muted={currentVideo.muted}
               autoPlay={true}
-              onEnded={handleVideoEnd} // Add this event handler
+              onEnded={handleVideoEnd}
               style={{ '--controls': 'none' } as React.CSSProperties}
             />
           </div>


### PR DESCRIPTION
I'm seeing some odd behaviour.

* Replay.io went live with an autoplaying video several hours ago
* Everything was working fine for hours, I have video proof!
* At 7:30pm PST, I noticed the video isn't auto-playing
     - I confirmed the same issue on the previous branch (localhost)
     - I confirmed the same issue on previous branch (vercel link)
     - I confirmed the issue on multiple browsers and OSes (although iOS worked, oddly)
* I checked mux.com to see if we hit some sort of limitation, don't see anything
* I tried setting autoplay=false and it works as expected with a big play button
* I tried a new branch pointing to a re-upload of our video and it works fine

So it doesn't seem to be browser or code related, from what I can tell. It seems like for some reason the previous MUX video URL just isn't working, except on iOS. Will share as I learn more.