### PR TITLE
Fix button on pricing page

### DIFF
--- a/src/components/primitives/button/index.tsx
+++ b/src/components/primitives/button/index.tsx
@@ -84,7 +84,9 @@ export const Button = forwardRef(
             rest.onClick(e)
           }
         }}
-      ></Comp>
+      >
+        <span style={{ position: 'relative', zIndex: 1 }}>{rest.children}</span>
+      </Comp>
     )
   }
 )


### PR DESCRIPTION
Here's a quick loom showing the change:
https://www.loom.com/share/8620b5a41d2541e59c8caed5ea480dc2

Here's the before and after visual:

Before:
<img width="399" alt="image" src="https://github.com/replayio/landing-page/assets/9154902/f7f1cfa2-2cae-4ffa-90cb-a096345c942c">

After:
<img width="386" alt="image" src="https://github.com/replayio/landing-page/assets/9154902/46926b23-8c84-4438-9091-04a056bf1d78">

I clicked around but I'm not sure I'm not going to break anything with this change.