### PR TITLE
Make feature types consistent

### DIFF
--- a/src/components/sections/DevTools.tsx
+++ b/src/components/sections/DevTools.tsx
@@ -13,22 +13,9 @@ import network from '~/images/screenshots/view-network-requests.png'
 import { LandingPageFragment } from '~/lib/basehub-queries'
 
 const images = {
-  testSteps: {
-    type: 'image',
-    src: testSteps
-  },
-  console: {
-    type: 'mux-video',
-    src: '9ERwx5ymPqmmqMeRIhVqCvnhyy009017y00mtdvISQF6fI'
-  },
-  react: {
-    type: 'image',
-    src: react
-  },
-  network: {
-    type: 'image',
-    src: network
-  }
+  testSteps,
+  react,
+  network
 }
 
 export function DevTools({ devTools }: LandingPageFragment) {
@@ -124,7 +111,7 @@ export function DevTools({ devTools }: LandingPageFragment) {
                         {feature.type === 'image' ? (
                           <Image
                             className="w-full"
-                            src={featureImage.src}
+                            src={featureImage}
                             alt=""
                             priority
                             sizes="(min-width: 1024px) 67.8125rem, (min-width: 640px) 100vw, 45rem"
@@ -132,7 +119,7 @@ export function DevTools({ devTools }: LandingPageFragment) {
                         ) : (
                           <MuxPlayer
                             streamType="on-demand"
-                            playbackId={featureImage.src as string}
+                            playbackId={feature.video as string}
                             primaryColor="#FFFFFF"
                             secondaryColor="#000000"
                             muted={true}
@@ -181,19 +168,18 @@ export function DevTools({ devTools }: LandingPageFragment) {
                       </div>
                     </h3>
                     <p className={clsx('mb-8 mt-2 text-sm')}>{feature.subTitle}</p>
-                    {featureImage.type === 'image' && (
+                    {feature.type === 'image' ? (
                       <Image
                         className="w-full"
-                        src={featureImage.src}
+                        src={featureImage}
                         alt=""
                         priority
                         sizes="(min-width: 1024px) 67.8125rem, (min-width: 500px) 100vw, 30rem"
                       />
-                    )}
-                    {featureImage.type === 'mux-video' && (
+                    ) : (
                       <MuxPlayer
                         streamType="on-demand"
-                        playbackId={featureImage.src as string}
+                        playbackId={feature.video as string}
                         primaryColor="#FFFFFF"
                         secondaryColor="#ff00ff"
                         muted={true}


### PR DESCRIPTION
We've gone back and forth a couple of times here because of a miscommunication.

I think this should simplify things considerably:
1. BaseHub is the source of truth for whether a feature is an image or video
2. BaseHub has the video id. Eventually it'll also have the video and the image as well. That's what we're doing on docs and it's simpler.
3. The code has the minimal amount of code needed to support images that are in the repo.