### PR TITLE
Update pricing table

### DIFF
--- a/src/components/pricing/PricingTooltip.tsx
+++ b/src/components/pricing/PricingTooltip.tsx
@@ -7,20 +7,26 @@ import Link from 'next/link'
 export const PricingTooltip = ({
   children,
   body,
-  learnMore
+  learnMore,
+  highlighted
 }: {
   learnMore?: string
   body: string
   children: React.ReactNode
+  highlighted?: boolean
 }) => {
   if (!body) return children
+  const tooltipClassName = highlighted
+    ? 'bg-indigo-500 border-indigo-200'
+    : 'border-slate-500 bg-slate-800'
+  const tooltipArrowClassName = highlighted ? 'fill-indigo-800' : 'fill-slate-800'
   return (
     <Tooltip.Provider>
       <Tooltip.Root>
         <Tooltip.Trigger asChild>{children}</Tooltip.Trigger>
         <Tooltip.Portal>
           <Tooltip.Content
-            className={`borderPrimaryAccent max-w-64 select-none rounded-[4px] border-t-4 border-red-500 bg-slate-100 px-[15px] py-[10px] text-[15px] text-sm leading-relaxed text-gray-800 shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity] data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade`}
+            className={`${tooltipClassName} borderPrimaryAccent max-w-64 select-none rounded-[4px] border-t-4   px-[15px] py-[10px] text-[15px] text-sm leading-relaxed text-slate-100 shadow-[hsl(206_22%_7%_/_35%)_0px_10px_38px_-10px,_hsl(206_22%_7%_/_20%)_0px_10px_20px_-15px] will-change-[transform,opacity] data-[state=delayed-open]:data-[side=bottom]:animate-slideUpAndFade data-[state=delayed-open]:data-[side=left]:animate-slideRightAndFade data-[state=delayed-open]:data-[side=right]:animate-slideLeftAndFade data-[state=delayed-open]:data-[side=top]:animate-slideDownAndFade`}
             sideOffset={0}
             alignOffset={0}
             align="start"
@@ -29,14 +35,14 @@ export const PricingTooltip = ({
               <p>{body}</p>
               {learnMore && (
                 <div className="mt-2">
-                  <Link className="text-gray-600 underline" href={learnMore}>
+                  <Link className="text-slate-200 underline" href={learnMore}>
                     Learn more
                   </Link>
                 </div>
               )}
             </div>
 
-            <Tooltip.Arrow className="fill-white" />
+            <Tooltip.Arrow className={tooltipArrowClassName} />
           </Tooltip.Content>
         </Tooltip.Portal>
       </Tooltip.Root>

--- a/src/components/pricing/sections/PricingHero.tsx
+++ b/src/components/pricing/sections/PricingHero.tsx
@@ -83,6 +83,7 @@ function Plan({ tier }: { tier: Tier }) {
                 key={label}
                 learnMore={FEATURES[label].learnMore}
                 body={FEATURES[label].description}
+                highlighted={tier.featured}
               >
                 <li
                   className={`flex items-center justify-between border-b py-2 ${tier.featured ? 'border-indigo-500' : 'border-slate-700'}`}

--- a/src/components/pricing/sections/comparison.ts
+++ b/src/components/pricing/sections/comparison.ts
@@ -21,14 +21,14 @@ export const FEATURES: Record<string, Feature> = {
   },
   recordings: {
     name: 'Uploaded recordings',
-    description: `By default all failed tests are uploaded, but we recommend also uploading all recordings for atleast one run a day so you have a reference point.`,
-    learnMore: '#'
+    description: `By default all tests are uploaded, but it's easy to upload a subset of recordings to stay within the upload limits.`,
+    learnMore: 'https://docs.replay.io/ci-workflows/upload-strategies'
   },
   processed: {
-    name: 'Replayed recordings',
+    name: 'Instant replays',
     description:
-      'We try and replay a represantitive sample of your failed recordings so that you can start debugging them immediately.',
-    learnMore: '#'
+      'It typically takes about 30 seconds to view a new recording. On Pro plans, we replay some of the recordings ahead of time so that they’re immediately available.',
+    learnMore: ''
   },
   rca: {
     name: 'Root cause analysis *',
@@ -81,7 +81,7 @@ export const tiers: Record<string, Tier> = {
       users: 20,
       runs: 'Unlimited',
       recordings: 100,
-      processed: 20,
+      processed: 0,
       rca: 0,
       perf: 0,
       retention: '7 days',
@@ -116,7 +116,7 @@ export const tiers: Record<string, Tier> = {
       users: 20,
       runs: 'Unlimited',
       recordings: 1000,
-      processed: 100,
+      processed: 0,
       rca: 0,
       perf: 0,
       retention: '7 days',


### PR DESCRIPTION
This PR addresses feedback that I got reviewing the pricing page with folks from Grow Therapy where the idea of "Replayed recordings" scared them because it seemed important and very low.

This addresses that by doing a couple of things

* Rebranding Replayed recordings to "instant replays" which is both more descriptive and more of a nice to have
* Removing them from the free and cheap plan so it's even clearer you don't need it
* Making the description clearer as well.

This also restyles the tooltip to be a bit cleaner