### PR TITLE
Link to suite team team instead of standard team

### DIFF
--- a/src/components/pricing/sections/comparison.ts
+++ b/src/components/pricing/sections/comparison.ts
@@ -75,7 +75,7 @@ export const tiers: Record<string, Tier> = {
     featured: false,
     price: 0,
     description: 'For small teams with a handful of flaky E2E tests.',
-    href: 'https://app.replay.io/team/new',
+    href: 'https://app.replay.io/team/new/tests',
     priceDescription: 'No credit card required',
     features: {
       users: 20,
@@ -110,7 +110,7 @@ export const tiers: Record<string, Tier> = {
     price: 75,
     priceDescription: 'No credit card required',
     description: 'For teams with a growing test suite.',
-    href: 'https://app.replay.io/team/new',
+    href: 'https://app.replay.io/team/new/tests',
     featured: true,
     features: {
       users: 20,
@@ -146,7 +146,7 @@ export const tiers: Record<string, Tier> = {
     price: 350,
     priceDescription: 'No credit card required',
     description: 'For businesses who want to set E2E reliability goals.',
-    href: 'https://app.replay.io/team/new',
+    href: 'https://app.replay.io/team/new/tests',
     featured: false,
     features: {
       users: 50,

--- a/src/components/sections/homepage/bugs-slider/index.tsx
+++ b/src/components/sections/homepage/bugs-slider/index.tsx
@@ -557,7 +557,7 @@ const data: DataType[] = [
     description: (
       <>
         <br />
-        <Link href="https://app.replay.io/team/new" aria-label="Create a team">
+        <Link href="https://app.replay.io/team/new/tests" aria-label="Create a team">
           Create a team
         </Link>{' '}
         and start sharing replays with your team.

--- a/src/components/sections/homepage/use-cases/index.tsx
+++ b/src/components/sections/homepage/use-cases/index.tsx
@@ -18,7 +18,7 @@ const UseCases = () => {
     description: (
       <>
         <br />
-        <Link href="https://app.replay.io/team/new" aria-label="Create a team">
+        <Link href="https://app.replay.io/team/new/tests" aria-label="Create a team">
           Create a team
         </Link>{' '}
         and start sharing replays with your team.

--- a/src/components/sections/pricing/hero/index.tsx
+++ b/src/components/sections/pricing/hero/index.tsx
@@ -22,7 +22,7 @@ const bugreportingPlans = [
     price: 20,
     mode: 'per month / per developer',
     cta: 'Create team',
-    link: 'https://app.replay.io/team/new',
+    link: 'https://app.replay.io/team/new/tests',
     features: [
       '200 recordings per month',
       'Up to 10 users + developers',
@@ -35,7 +35,7 @@ const bugreportingPlans = [
     price: 75,
     mode: 'per month / per developer',
     cta: 'Create Organization',
-    link: 'https://app.replay.io/team/new',
+    link: 'https://app.replay.io/team/new/tests',
     features: [
       '1,000 recordings per month',
       'Up to 100 users + developers',

--- a/src/components/sections/pricing/plans/index.tsx
+++ b/src/components/sections/pricing/plans/index.tsx
@@ -68,7 +68,7 @@ export const bugreportingPlans: Plan[] = [
     description:
       'Team workspaces make it easy to collaborate, manage recordings, and track conversations so that bugs get fixed faster.',
     cta: 'Create Team',
-    link: 'https://app.replay.io/team/new',
+    link: 'https://app.replay.io/team/new/tests',
     content: [
       {
         title: 'Only pay for developers on your team',
@@ -95,7 +95,7 @@ export const bugreportingPlans: Plan[] = [
     description:
       'Organization includes Team workspaces with additional controls around access and recordings, SSO / SAML integration and Enterprise Security features.',
     cta: 'Create Organization',
-    link: 'https://app.replay.io/team/new',
+    link: 'https://app.replay.io/team/new/tests',
     content: [
       {
         features: {


### PR DESCRIPTION
We talk exclusively test suite in pricing page, linking to tests team makes more sense.