### PR TITLE
PRO-2372: capture ad attribution to .replay.io cookie

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,49 @@ import markdownAgentTokens from './lib/markdown-agent-tokens.json'
 
 const MARKDOWN_TOKEN_BY_PATH = markdownAgentTokens as Record<string, number>
 
+// ad attribution — first-touch capture of paid-ad click IDs + utms as a
+// .replay.io cookie, so the value survives the replay.io -> app.replay.io
+// subdomain hop (localStorage is origin-scoped and wouldn't). the 90d
+// max-age matches the CVR window the ad platforms report against.
+// app.replay.io's dashboard reads this same cookie at /login time and
+// threads it into auth0's authorizationParams -> backend ensureUserForAuth.
+const AD_ATTR_KEYS = [
+  'li_fat_id',
+  'twclid',
+  'rdt_cid',
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_content',
+  'utm_term'
+] as const
+const AD_COOKIE_NAME = 'replay-ad-attribution'
+const AD_COOKIE_MAX_AGE = 60 * 60 * 24 * 90
+
+function setAdAttributionCookieIfNeeded(request: NextRequest, response: NextResponse): void {
+  if (request.cookies.has(AD_COOKIE_NAME)) return
+
+  const captured: Record<string, string> = {}
+  for (const k of AD_ATTR_KEYS) {
+    const v = request.nextUrl.searchParams.get(k)
+    if (v) captured[k] = v
+  }
+  if (Object.keys(captured).length === 0) return
+
+  // Domain=.replay.io lets app.replay.io read it; skip on preview /
+  // localhost so the cookie still writes as host-only for testing.
+  const isReplayHost = request.nextUrl.hostname.endsWith('replay.io')
+  response.cookies.set({
+    name: AD_COOKIE_NAME,
+    value: JSON.stringify(captured),
+    path: '/',
+    maxAge: AD_COOKIE_MAX_AGE,
+    sameSite: 'lax',
+    secure: request.nextUrl.protocol === 'https:',
+    ...(isReplayHost ? { domain: '.replay.io' } : {})
+  })
+}
+
 /** Map marketing pathname (no trailing slash, except '/') to static markdown under /agent/ */
 const MARKDOWN_BY_PATH: Record<string, string> = {
   '/': '/agent/index.md',
@@ -86,16 +129,20 @@ export function middleware(request: NextRequest) {
         Math.max(1, Math.ceil((request.nextUrl.pathname.length + 200) / 4))
       res.headers.set('x-markdown-tokens', String(approxTokens))
       appendDiscoveryLinkHeaders(res)
+      setAdAttributionCookieIfNeeded(request, res)
       return res
     }
   }
 
   if (shouldSkipAgentHeaders(pathname)) {
-    return NextResponse.next()
+    const res = NextResponse.next()
+    setAdAttributionCookieIfNeeded(request, res)
+    return res
   }
 
   const res = NextResponse.next()
   appendDiscoveryLinkHeaders(res)
+  setAdAttributionCookieIfNeeded(request, res)
   return res
 }
 


### PR DESCRIPTION
captures paid-ad click IDs (`li_fat_id`, `twclid`, `rdt_cid`) + UTMs on every replay.io page visit and writes a `.replay.io` cookie so the value survives the hop to `app.replay.io`. ticket: PRO-2372.

## shape

- done in `src/middleware.ts` at the edge (no client component). runs before any JS hydration, so we capture on every paid-ad click regardless of whether the user stays long enough to render.
- **first-touch**: if `replay-ad-attribution` cookie is already set, do nothing. otherwise read the ad keys from `request.nextUrl.searchParams`, serialize to JSON, write one cookie.
- cookie: `Path=/; Max-Age=7776000` (90d, matches CVR window) `; SameSite=Lax; Secure` on https + `Domain=.replay.io` when hostname ends with `replay.io` (host-only on vercel previews + localhost for easy testing).
- existing ad pixels (LinkedIn Insight Tag, X conversion, Reddit Pixel + CAPI stub) unchanged.

## test plan

- [x] `yarn lint` clean
- [x] `npx tsc --noEmit` clean on changed files
- [ ] preview deploy: `/<any-page>?li_fat_id=smoke&utm_source=linkedin` — first response has `Set-Cookie: replay-ad-attribution=...`; second page load does NOT re-set
- [ ] prod: `curl -I 'https://www.replay.io/?li_fat_id=smoke'` shows cookie with `Domain=.replay.io`