### PR TITLE
add 301 redirects from blog.replay.io to replay.io/blog

### DIFF
--- a/src/lib/blog-redirect.ts
+++ b/src/lib/blog-redirect.ts
@@ -1,0 +1,74 @@
+import { slugify } from './slugify'
+
+/**
+ * Old blog.replay.io path (URL-decoded, leading `/` stripped) -> new
+ * www.replay.io/blog/<slug>.
+ *
+ * For most posts, slugify(oldPath) === newSlug, so the default path is
+ * slugify-the-old-path. The entries here cover the cases where the old
+ * hashnode/notaku slug and the new notion slug genuinely diverge:
+ *
+ * - `0%` / `<>` / `&` got transliterated to "percent" / "lessgreater" by
+ *   the old generator, but the new slugify just drops them.
+ * - Two posts share a title and the new system disambiguates with `-2`
+ *   while the old URLs carried hex notion-page-id suffixes; we map the
+ *   older one to `-2` based on publish dates pulled from the old RSS feed
+ *   and the new page bodies.
+ * - Old hashnode "/replay-employees" sub-paths were discussion threads on
+ *   a post; collapse them to the base post.
+ * - A couple of titles have an ASCII apostrophe in hashnode but a smart
+ *   apostrophe in notion (or vice-versa), so the slugs differ by `-s` vs
+ *   `s` / `-t` vs `t`.
+ */
+const OVERRIDES: Record<string, string> = {
+  'a-journey-of-driving-down-test-flakes-to-0percent-at-metabase-part-1':
+    'a-journey-of-driving-down-test-flakes-to-0-at-metabase-part-1',
+  'a-journey-of-driving-down-test-flakes-to-0percent-at-metabase-part-2':
+    'a-journey-of-driving-down-test-flakes-to-0-at-metabase-part-2',
+  'a-journey-of-driving-down-test-flakes-to-0percent-at-metabase-part-3':
+    'a-journey-of-driving-down-test-flakes-to-0-at-metabase-part-3',
+  'a-new-direction/replay-employees': 'a-new-direction',
+  'changelog-54:-54percent-faster-recording': 'changelog-54-54-faster-recording',
+  // 436fbf... was published 2023-08-11 and is the one whose date is shown on the new
+  // unsuffixed page. 7c6cd... was 2023-08-03 and is the disambiguated -2.
+  'changelog-57:-redux-devtools-436fbf05e421473c80dc7882cbeda045': 'changelog-57-redux-devtools',
+  'changelog-57:-redux-devtools-7c6cd447b48f4e3b9d0b6b6c5eabeef5': 'changelog-57-redux-devtools-2',
+  'changelog-66:-replayability-roadmap/replay-employees': 'changelog-66-replayability-roadmap',
+  // notion title uses an ASCII apostrophe, new slug keeps `nadia-s` / `haven-t` via
+  // the canonical slugify path. but the hashnode URL also used ASCII, so the default
+  // slugify(oldPath) already lands on `nadia-s` etc - except the live notion title for
+  // these particular posts seems to use smart quotes, producing `nadias` / `replays`.
+  // override to land on the live slug.
+  'replay-time-travelogue:-improving-nadia\'s-"debugging-with-ai"-results-using-replay-mcp':
+    'replay-time-travelogue-improving-nadias-debugging-with-ai-results-using-replay-mcp',
+  "replay's-recording-roadmap": 'replays-recording-roadmap',
+  'tablecheck-transforms-qa-lessgreater-dev-communication-to-support-thousands-of-restaurants-and-hotel-chains':
+    'tablecheck-transforms-qa-dev-communication-to-support-thousands-of-restaurants-and-hotel-chains',
+  // 955f... was published 2020-08-10 and matches the date shown on the new unsuffixed
+  // page. 3e1c... was 2022-12-22 (most likely a republish/duplicate) and gets -2.
+  'week-3:-thinking-tools-955f283277e1444b8da6be1405d84e85': 'week-3-thinking-tools',
+  'week-3:-thinking-tools-3e1c7353476b4648832925496358be6e': 'week-3-thinking-tools-2'
+}
+
+/**
+ * Resolve an old blog.replay.io request path to a new www.replay.io path.
+ * Always returns a path under /blog (the root `/` maps to `/blog`).
+ * `pathname` may be URL-encoded (e.g. `nadia%27s`); we decode before
+ * lookup. Starts with `/`.
+ */
+export function resolveBlogRedirect(pathname: string): string {
+  let decoded: string
+  try {
+    decoded = decodeURIComponent(pathname)
+  } catch {
+    decoded = pathname
+  }
+  const trimmed = decoded.replace(/^\/+/, '').replace(/\/+$/, '')
+  if (!trimmed) return '/blog'
+
+  const override = OVERRIDES[trimmed]
+  if (override) return `/blog/${override}`
+
+  const slug = slugify(trimmed)
+  return slug ? `/blog/${slug}` : '/blog'
+}

--- a/src/lib/notion-blog.ts
+++ b/src/lib/notion-blog.ts
@@ -7,6 +7,7 @@ import type {
 } from '@notionhq/client/build/src/api-endpoints'
 import { NotionToMarkdown } from 'notion-to-md'
 import { unstable_cache } from 'next/cache'
+import { slugify } from './slugify'
 
 /**
  * Tag used to invalidate the cached blog posts list from the revalidate-blog
@@ -183,20 +184,6 @@ const getCoverImageUrl = (page: FullPageRow): string | null => {
   if (page.cover.type === 'external') return page.cover.external.url
   if (page.cover.type === 'file') return page.cover.file.url
   return null
-}
-
-const slugify = (input: string) => {
-  return input
-    .normalize('NFKD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .toLowerCase()
-    .replace(/[\u2018\u2019\u201A\u201B]/g, '')
-    .replace(/[\u201C\u201D\u201E\u201F]/g, '')
-    .replace(/[\u2013\u2014\u2212]/g, '-')
-    .replace(/[\u2026]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '')
 }
 
 const toUniqueSlugs = (titles: string[]) => {

--- a/src/lib/slugify.ts
+++ b/src/lib/slugify.ts
@@ -1,0 +1,26 @@
+/**
+ * Stable slug derivation for blog post titles. Shared between the notion-blog
+ * loader (server-only) and the blog.replay.io middleware redirect (edge), so
+ * both sides land on the same /blog/<slug> when reasonable.
+ *
+ * Behavior notes:
+ * - Smart single quotes (‘, ’, ‚, ‛) are dropped, not hyphenated.
+ *   ASCII apostrophes (U+0027) hit the [^a-z0-9]+ rule and become '-'. Notion
+ *   titles vary between the two, which is why some existing slugs are `replays`
+ *   and one is `haven-t` - both are preserved.
+ * - Smart double quotes (“-‟) are dropped.
+ * - en/em/minus dashes collapse to a single '-' via the alphanumeric rule.
+ */
+export function slugify(input: string): string {
+  return input
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '')
+    .toLowerCase()
+    .replace(/[‘’‚‛]/g, '')
+    .replace(/[“”„‟]/g, '')
+    .replace(/[–—−]/g, '-')
+    .replace(/[…]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,20 @@
 import { NextResponse, type NextRequest } from 'next/server'
 import markdownAgentTokens from './lib/markdown-agent-tokens.json'
+import { resolveBlogRedirect } from './lib/blog-redirect'
 
 const MARKDOWN_TOKEN_BY_PATH = markdownAgentTokens as Record<string, number>
+
+const BLOG_LEGACY_HOST = 'blog.replay.io'
+const BLOG_NEW_ORIGIN = 'https://www.replay.io'
+
+function blogLegacyRedirect(request: NextRequest): NextResponse | null {
+  const host = request.headers.get('host')
+  if (host !== BLOG_LEGACY_HOST) return null
+
+  const target = new URL(resolveBlogRedirect(request.nextUrl.pathname), BLOG_NEW_ORIGIN)
+  target.search = request.nextUrl.search
+  return NextResponse.redirect(target, 301)
+}
 
 // ad attribution — first-touch capture of paid-ad click IDs + utms as a
 // .replay.io cookie, so the value survives the replay.io -> app.replay.io
@@ -115,6 +128,9 @@ function appendDiscoveryLinkHeaders(response: NextResponse): void {
 }
 
 export function middleware(request: NextRequest) {
+  const blogRedirect = blogLegacyRedirect(request)
+  if (blogRedirect) return blogRedirect
+
   const pathname = request.nextUrl.pathname
 
   if (wantsMarkdown(request)) {
@@ -148,5 +164,10 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/', '/((?!_next|api|.*\\..*).*)']
+  // dropped the `.*\\..*` exclusion that used to skip file-extension paths:
+  // blog.replay.io has post slugs like `launching-nut.new` and `changelog-30:-redux-devtools-v0.5`
+  // that need to flow through this middleware so they can be 301'd. for replay.io
+  // traffic, shouldSkipAgentHeaders short-circuits those same paths inside the
+  // handler, so the extra invocations are cheap.
+  matcher: ['/', '/((?!_next|_vercel|api).*)']
 }


### PR DESCRIPTION
migrated the blog from `blog.replay.io` to `replay.io/blog`. this PR 301s every old URL to its new home.

| file | what |
|---|---|
| `src/middleware.ts` | host check on `blog.replay.io`, 301 to `www.replay.io/blog/<slug>` with query preserved |
| `src/lib/blog-redirect.ts` | resolver: 13-entry override map, fallback is `slugify(oldPath)` |
| `src/lib/slugify.ts` | extracted from notion-blog.ts so edge middleware can import it |

verified 158/158 old sitemap entries map to live new slugs (146 via slugify, 12 via override).

## test plan
- [ ] `curl -sI https://blog.replay.io/web-debug-bench` returns 301 to `https://www.replay.io/blog/web-debug-bench`