### PR TITLE
Rewrite Notion links that carry a block anchor

### DIFF
--- a/src/app/blog/components/BlogPostBody.tsx
+++ b/src/app/blog/components/BlogPostBody.tsx
@@ -20,7 +20,19 @@ import 'prismjs/components/prism-yaml'
  * point at no recoverable target, so we render the text without an anchor instead of
  * emitting a link we know is broken.
  */
-const BARE_NOTION_ID = /^\/?([0-9a-f]{32})$/i
+/**
+ * A bare Notion page id used as a path, optionally followed by a block anchor or a
+ * query string: `/<32-hex>`, `/<32-hex>#<32-hex>`, `/<32-hex>?foo=bar`.
+ *
+ * The trailing group matters. An earlier version anchored straight to the end of
+ * the string, so links carrying a Notion block anchor (`/<id>#<id>`) fell through
+ * unrewritten and stayed as 404s.
+ *
+ * The path must be *only* the id, which is what keeps legitimate external links
+ * containing a 32-hex segment (Loom shares, GitHub gists, notion.so pages) from
+ * matching: those start with a scheme rather than the id.
+ */
+const BARE_NOTION_ID = /^\/?([0-9a-f]{32})(?:[?#].*)?$/i
 
 function resolveNotionHref(
   href: string | null | undefined,

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -241,6 +241,41 @@ test.describe('redirects', () => {
   })
 })
 
+test.describe('blog', () => {
+  test('no post links to a bare Notion page id', async ({ request }) => {
+    test.setTimeout(5 * 60 * 1000)
+
+    const xml = await (await request.get(`${BASE}/sitemap.xml`)).text()
+    const posts = [...xml.matchAll(/<loc>([^<]*\/blog\/[^<]+)<\/loc>/g)].map((m) => m[1])
+
+    if (posts.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log('note: no blog posts available (NOTION_TOKEN unset); skipping')
+      return
+    }
+
+    // Links authored in Notion serialise as a bare page id and 404. The path must be
+    // only the id: external links that merely contain a 32-hex segment (Loom shares,
+    // GitHub gists, notion.so pages) are legitimate and must not be reported.
+    //
+    // The optional trailing group is the point of this test. The first version of the
+    // fix anchored to the end of the string, so `/<id>#<block-id>` links survived and
+    // stayed as 404s until Ahrefs found them.
+    const BARE_ID_HREF = /href="\/[0-9a-f]{32}(?:[?#][^"]*)?"/gi
+
+    const offenders: string[] = []
+    for (const url of posts) {
+      const html = await (await request.get(url)).text()
+      const hits = html.match(BARE_ID_HREF)
+      if (hits) offenders.push(`${new URL(url).pathname} -> ${[...new Set(hits)].join(' ')}`)
+    }
+
+    expect(offenders, `posts still linking to a bare Notion id:\n${offenders.join('\n')}`).toEqual(
+      []
+    )
+  })
+})
+
 test.describe('internal links', () => {
   test('no page links to a path that does not exist', async ({ request }) => {
     const seen = new Set<string>()


### PR DESCRIPTION
Follow-up to #332, from the Ahrefs crawl of 4 Aug.

## The bug

That crawl still showed **5 bare Notion page ids 404ing** across 4 changelog
posts. They all take one form:

```
/1f5afb2cf5ad45a488369e65a821039d#7d7446b1cf6e4af8912105b18c488a26
```

A Notion page id with a **block anchor** appended. `BARE_NOTION_ID` anchored
straight to the end of the string, so anything carrying a fragment or query
fell through unrewritten and stayed a 404. It now allows an optional trailing
`[?#]...` group.

Affected: `changelog-19-focus-mode`, `changelog-21-playwright-tests` (two),
`changelog-38-broken-glass`, `changelog-46-chrome-palooza`.

## Why the earlier verification missed it

After the first fix I swept all 161 posts and reported zero remaining. That
sweep used `href="/<32-hex>"` — the same too-narrow pattern as the bug itself,
so it confirmed its own blind spot. Ahrefs found what the check could not.

## Not over-matching

The path must still be *only* the id. There are **242 other hrefs in the blog
containing a 32-hex segment** that are legitimate external links and must not be
touched: Loom shares, GitHub gists, notion.so pages, a GitHub PR diff anchor.
The regex was tested against all of those shapes plus the six that should match.

## Regression test

`tests/seo.spec.ts` now scans every post in the sitemap for the pattern,
fragment form included. Confirmed it **fails against current production** with
exactly the 5 URLs Ahrefs reported, across the same 4 posts, and passes locally
where the blog is empty.

Build clean, lint clean, 43 tests pass.

## Not in this PR

The same crawl flagged **115 orphan pages** (114 blog posts plus `/debugging`).
The blog index server-renders only the first 24 posts and loads the rest client
side, so crawlers never see links to the other 137. That is pre-existing and
only became visible now the posts are correctly in the sitemap. It needs a
design decision rather than a quick fix.
