### PR TITLE
Add a crawlable blog archive and restore the /debugging link

### DIFF
--- a/src/app/blog/archive/page.tsx
+++ b/src/app/blog/archive/page.tsx
@@ -1,0 +1,140 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+import { Footer } from '~/components/Footer'
+import { Header } from '~/components/layout/header'
+import { Container } from '~/components/Container'
+import { defaultMeta, siteOrigin } from '~/lib/constants'
+import { getBlogPosts, type BlogPost } from '~/lib/notion-blog'
+
+const title = 'Blog Archive: Every Replay Post'
+const description =
+  'A complete index of every post on the Replay blog, from engineering deep dives to changelog updates, listed by year.'
+
+export const metadata: Metadata = {
+  title,
+  description,
+  alternates: {
+    canonical: `${siteOrigin}/blog/archive`
+  },
+  openGraph: {
+    type: 'website',
+    url: `${siteOrigin}/blog/archive`,
+    title,
+    description,
+    images: [{ url: defaultMeta.ogImage, width: 1200, height: 630 }]
+  },
+  twitter: {
+    card: 'summary_large_image',
+    site: defaultMeta.twitter.site,
+    title,
+    description,
+    creator: defaultMeta.twitter.handle,
+    images: [{ url: defaultMeta.ogImage, width: 1200, height: 630 }]
+  }
+}
+
+// Matches /blog. The Notion data layer refreshes its own cache every 15 min.
+export const revalidate = 1800
+
+const YEAR_UNKNOWN = 'Undated'
+
+const formatDate = (date: string | null) =>
+  date ? new Date(date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : null
+
+/** Group posts by publication year, newest year first, preserving the incoming order. */
+function groupByYear(posts: BlogPost[]): Array<[string, BlogPost[]]> {
+  const groups = new Map<string, BlogPost[]>()
+
+  for (const post of posts) {
+    const year = post.publishedAt ? String(new Date(post.publishedAt).getFullYear()) : YEAR_UNKNOWN
+    const bucket = groups.get(year)
+    if (bucket) bucket.push(post)
+    else groups.set(year, [post])
+  }
+
+  return [...groups.entries()].sort(([a], [b]) => {
+    if (a === YEAR_UNKNOWN) return 1
+    if (b === YEAR_UNKNOWN) return -1
+    return Number(b) - Number(a)
+  })
+}
+
+/**
+ * A plain, fully server-rendered index of every post.
+ *
+ * /blog server-renders only its first page of posts and loads the rest client side,
+ * so a crawler never sees a link to the remainder. Ahrefs reported 114 posts as
+ * orphaned for exactly that reason. This page gives every post one crawlable
+ * internal link without changing how /blog behaves for readers.
+ */
+export default async function BlogArchivePage() {
+  const posts = await getBlogPosts()
+  const byYear = groupByYear(posts)
+
+  return (
+    <>
+      <Header />
+
+      <main className="bg-white pb-20 pt-[calc(var(--site-header-offset)+2rem)] sm:pt-[calc(var(--site-header-offset)+3rem)]">
+        <Container>
+          <section className="mx-auto max-w-3xl text-center">
+            <p className="text-sm font-semibold uppercase tracking-[0.2em] text-accent">
+              Replay.io Blog
+            </p>
+            <h1 className="mt-3 text-4xl font-semibold tracking-tight text-gray-950 sm:text-5xl">
+              Archive
+            </h1>
+            <p className="mt-4 text-base text-gray-600 sm:text-lg">
+              Every post we have published, newest first.{' '}
+              <Link href="/blog" className="text-accent underline-offset-4 hover:underline">
+                Back to the blog
+              </Link>
+              .
+            </p>
+          </section>
+
+          {posts.length === 0 ? (
+            <p className="mx-auto mt-16 max-w-3xl text-center text-gray-600">
+              No posts to show right now.
+            </p>
+          ) : (
+            <div className="mx-auto mt-16 max-w-3xl">
+              {byYear.map(([year, yearPosts]) => (
+                <section key={year} className="mb-12">
+                  <h2 className="mb-4 border-b border-gray-200 pb-2 text-sm font-semibold uppercase tracking-[0.2em] text-gray-500">
+                    {year}
+                  </h2>
+                  <ul className="space-y-1">
+                    {yearPosts.map((post) => {
+                      const date = formatDate(post.publishedAt)
+                      return (
+                        <li key={post.slug}>
+                          <Link
+                            href={`/blog/${post.slug}`}
+                            className="flex flex-col gap-1 rounded-lg px-3 py-2.5 transition-colors hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:flex-row sm:items-baseline sm:justify-between sm:gap-6"
+                          >
+                            <span className="text-base text-gray-900">{post.title}</span>
+                            {date ? (
+                              <time
+                                dateTime={post.publishedAt!}
+                                className="flex-none text-sm tabular-nums text-gray-500"
+                              >
+                                {date}
+                              </time>
+                            ) : null}
+                          </Link>
+                        </li>
+                      )
+                    })}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
+        </Container>
+      </main>
+
+      <Footer />
+    </>
+  )
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from 'next'
+import Link from 'next/link'
 import { Footer } from '~/components/Footer'
 import { Header } from '~/components/layout/header'
 import { Container } from '~/components/Container'
@@ -8,7 +9,8 @@ import { BlogPostsExplorer } from './components/BlogPostsExplorer'
 
 export const metadata: Metadata = {
   title: 'Replay Blog: Debugging, Testing and Changelog',
-  description: 'Engineering stories, changelog updates and guides from the Replay team on debugging, time-travel and automated QA for modern web apps.',
+  description:
+    'Engineering stories, changelog updates and guides from the Replay team on debugging, time-travel and automated QA for modern web apps.',
   alternates: {
     canonical: `${siteOrigin}/blog`
   },
@@ -16,14 +18,16 @@ export const metadata: Metadata = {
     type: 'website',
     url: `${siteOrigin}/blog`,
     title: 'Replay Blog: Debugging, Testing and Changelog',
-    description: 'Engineering stories, changelog updates and guides from the Replay team on debugging, time-travel and automated QA for modern web apps.',
+    description:
+      'Engineering stories, changelog updates and guides from the Replay team on debugging, time-travel and automated QA for modern web apps.',
     images: [{ url: defaultMeta.ogImage, width: 1200, height: 630 }]
   },
   twitter: {
     card: 'summary_large_image',
     site: defaultMeta.twitter.site,
     title: 'Replay Blog: Debugging, Testing and Changelog',
-    description: 'Engineering stories, changelog updates and guides from the Replay team on debugging, time-travel and automated QA for modern web apps.',
+    description:
+      'Engineering stories, changelog updates and guides from the Replay team on debugging, time-travel and automated QA for modern web apps.',
     creator: defaultMeta.twitter.handle,
     images: [{ url: defaultMeta.ogImage, width: 1200, height: 630 }]
   }
@@ -56,6 +60,16 @@ export default async function BlogPage() {
             </h1>
             <p className="mt-4 text-base text-gray-600 sm:text-lg">
               Product updates, case studies, and debugging insights from the Replay team.
+            </p>
+            {/* This page server-renders only its first batch of posts and loads the rest
+                client side, so crawlers never reach the remainder. The archive gives every
+                post one crawlable internal link. */}
+            <p className="mt-3 text-sm text-gray-500">
+              Looking for something older?{' '}
+              <Link href="/blog/archive" className="text-accent underline-offset-4 hover:underline">
+                Browse the full archive
+              </Link>
+              .
             </p>
           </section>
 

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -23,6 +23,7 @@ const ROUTES: Array<{ path: string; priority: number; changeFrequency: ChangeFre
   { path: '/precog', priority: 0.8, changeFrequency: 'monthly' },
   { path: '/roi-calculator', priority: 0.7, changeFrequency: 'monthly' },
   { path: '/blog', priority: 0.7, changeFrequency: 'weekly' },
+  { path: '/blog/archive', priority: 0.5, changeFrequency: 'weekly' },
   { path: '/about', priority: 0.6, changeFrequency: 'monthly' },
   { path: '/contact', priority: 0.6, changeFrequency: 'yearly' },
   { path: '/security-and-privacy', priority: 0.4, changeFrequency: 'yearly' },

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -115,7 +115,9 @@ const NAV_LINKS = [
   { label: 'Home', href: '/' },
   { label: 'Pricing', href: '/pricing' },
   { label: 'ROI Calculator', href: '/roi-calculator' },
-  // { label: 'Debugging', href: '/debugging' },
+  // Restored: /debugging is in the sitemap but nothing linked to it, so Ahrefs
+  // reported it as an orphan page.
+  { label: 'Debugging', href: '/debugging' },
   { label: 'About', href: '/about' },
   { label: 'Blog', href: navigation.company[0].href },
   { label: 'Contact', href: '/contact' }

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -18,6 +18,7 @@ const ROUTES = [
   '/',
   '/about',
   '/blog',
+  '/blog/archive',
   '/branding',
   '/contact',
   '/debugging',
@@ -257,7 +258,10 @@ test.describe('internal links', () => {
     // empty, so links to individual posts would 404 for reasons unrelated to this
     // check. Detect that and exclude post links rather than reporting false failures.
     const sitemapXml = await (await request.get(`${BASE}/sitemap.xml`)).text()
-    const blogAvailable = sitemapXml.includes('/blog/')
+    // Must exclude /blog/archive, which is a static route and present in the sitemap
+    // whether or not any posts exist. Matching a bare '/blog/' made this read as
+    // "posts available" with no Notion token, and the post links then 404'd.
+    const blogAvailable = /\/blog\/(?!archive\b)[^<"\s]+/.test(sitemapXml)
     if (!blogAvailable) {
       // eslint-disable-next-line no-console
       console.log('note: no blog posts available (NOTION_TOKEN unset); skipping /blog/* links')
@@ -265,7 +269,7 @@ test.describe('internal links', () => {
 
     const broken: string[] = []
     for (const path of seen) {
-      if (!blogAvailable && /^\/blog\/.+/.test(path)) continue
+      if (!blogAvailable && /^\/blog\/(?!archive$).+/.test(path)) continue
       const res = await request.get(`${BASE}${path}`, { maxRedirects: 0 })
       // 2xx is fine; 3xx is an intentional redirect. 4xx is not.
       if (res.status() >= 400) broken.push(`${path} -> ${res.status()}`)


### PR DESCRIPTION
Closes the **115 orphan pages** reported by the Ahrefs crawl of 4 Aug: 114 blog
posts plus `/debugging`.

Both are pre-existing. They only became visible once #332 fixed the sitemap, so
Ahrefs could finally see these pages and notice nothing links to them.

## Blog posts (114)

`/blog` server-renders only its first 24 posts (`INITIAL_PAGE_SIZE`) and loads
the remaining 137 client side, so a crawler never sees a link to them.

`/blog/archive` is a plain, fully server-rendered index of every post, grouped by
year, linked from `/blog`. Every post now has one crawlable internal link and
`/blog` is unchanged for readers.

Deliberately lightweight: titles and dates only, no cover images, so a
161-entry page stays small. It reuses the existing header, footer and container,
and carries a full metadata set like every other route.

## /debugging (1)

`NAV_LINKS` in the footer already had a commented-out entry for it. This
restores that line rather than inventing new navigation.

## A bug this exposed in the tests

The internal-link crawl decided whether blog posts existed by checking the
sitemap for `/blog/`. Adding `/blog/archive` satisfied that on its own, so with
no `NOTION_TOKEN` the check read as "posts available" and then reported every
post link as a 404. It now matches post URLs specifically.

Worth noting the suite caught this itself on the first run after the change.

## Verification

- Build clean, lint clean, **44 tests pass** (`/blog/archive` is in `ROUTES`, so
  it gets the same h1, metadata, Open Graph, canonical and alt-text assertions)
- `/blog/archive` is in the sitemap
- The footer `/debugging` link is present on every built page
- The archive renders an empty state rather than crashing when Notion returns
  nothing, which is what happens in local dev

**Needs a preview check:** as with the earlier blog work, local dev has no
`NOTION_TOKEN`, so the archive renders empty here. On the preview, confirm
`/blog/archive` lists all ~161 posts and that they are grouped sensibly by year:

```bash
curl -s https://<preview>/blog/archive | grep -oE 'href="/blog/[^"]+"' | sort -u | wc -l
```
