### PR TITLE
Finish the Ahrefs findings: docs links, canonical URLs, blog metadata

### DIFF
--- a/docs-redirects-handoff.md
+++ b/docs-redirects-handoff.md
@@ -1,5 +1,13 @@
 # docs.replay.io redirect handoff
 
+> **Status, 4 Aug 2026:** none of these had been actioned, so the marketing site now
+> rewrites these links in its blog renderer as a stopgap (`src/lib/docs-links.ts`).
+> That only repairs links on www.replay.io. Redirects on the docs property are still
+> the right fix: they would also repair external backlinks, bookmarks and Google's
+> index, and would let the shim be deleted. One extra finding while mapping them:
+> `/learn-more/contribute/how-replay-works/our-approach-for-source-maps` currently
+> 308s to the **Redux panel**, which looks like a mistake.
+
 Source: Ahrefs crawl of replay.io, 28 Jul 2026 (exports dated 2026-08-03).
 
 Two separate Ahrefs reports (`404 pages` and `Page has links to broken page`)

--- a/next.config.js
+++ b/next.config.js
@@ -17,6 +17,11 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, 'src')]
   },
+  // Blog posts are prerendered from Notion, and `pageToMarkdown` walks a page block
+  // by block. When Notion rate limits the build, withNotionRetry's exponential
+  // backoff can legitimately push a single long post past Next's 60s default and
+  // fail the whole deploy. 180s leaves room for the retries to settle.
+  staticPageGenerationTimeout: 180,
   async rewrites() {
     return [
       {

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { Header } from '~/components/layout/header'
 import { Container } from '~/components/Container'
 import { defaultMeta, siteOrigin } from '~/lib/constants'
 import { getBlogPostBySlug, getBlogPosts, getNotionIdToSlugMap } from '~/lib/notion-blog'
+import { buildPostDescription, buildPostTitle } from '~/lib/blog-metadata'
 import { BlogPostBody } from '../components/BlogPostBody'
 
 type BlogPostPageProps = {
@@ -37,13 +38,19 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
     }
   }
 
-  const { post } = postData
+  const { post, markdown } = postData
   const url = `${siteOrigin}/blog/${post.slug}`
-  const description = post.excerpt || 'Read the latest engineering updates from Replay.'
+  // Notion's Description property is frequently far under or over the length search
+  // engines will show, so top it up from the post body or trim it as needed.
+  const description = buildPostDescription(
+    post.excerpt,
+    markdown,
+    'Read the latest engineering updates from Replay.'
+  )
   const image = post.coverImageUrl || defaultMeta.ogImage
 
   return {
-    title: `${post.title} — Replay Blog`,
+    title: buildPostTitle(post.title),
     description,
     alternates: {
       canonical: url

--- a/src/app/blog/components/BlogPostBody.tsx
+++ b/src/app/blog/components/BlogPostBody.tsx
@@ -1,6 +1,7 @@
 import { Marked } from 'marked'
 import { markedHighlight } from 'marked-highlight'
 import Prism from 'prismjs'
+import { resolveBlogRedirect } from '~/lib/blog-redirect'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-diff'
@@ -46,6 +47,42 @@ function resolveNotionHref(
   return slug ? `/blog/${slug}` : null
 }
 
+/**
+ * Point links at our own site straight at their canonical URL.
+ *
+ * Posts written over the years link to `http://replay.io/...`, the apex domain, and
+ * the retired `blog.replay.io`. Every one of those redirects, and the plain-http ones
+ * are worse than that: Ahrefs counts them as an HTTPS page linking to HTTP, which is
+ * an error rather than a warning. Rewriting them here removes the hop for readers and
+ * the finding for crawlers, without touching the Notion source.
+ *
+ * `blog.replay.io` paths go through the same slug mapping the middleware uses to 301
+ * that host, so the two cannot drift apart.
+ */
+function canonicaliseReplayHref(href: string): string {
+  let url: URL
+  try {
+    url = new URL(href)
+  } catch {
+    return href // relative, mailto:, anchors
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') return href
+
+  const host = url.hostname.toLowerCase()
+
+  if (host === 'blog.replay.io') {
+    const path = resolveBlogRedirect(url.pathname)
+    return `https://www.replay.io${path}${url.search}${url.hash}`
+  }
+
+  if (host === 'replay.io' || host === 'www.replay.io') {
+    return `https://www.replay.io${url.pathname}${url.search}${url.hash}`
+  }
+
+  return href
+}
+
 function createMarked(idToSlug: Record<string, string>) {
   const marked = new Marked(
     markedHighlight({
@@ -74,8 +111,9 @@ function createMarked(idToSlug: Record<string, string>) {
       },
       link({ href, title, tokens }) {
         const text = this.parser.parseInline(tokens)
-        const resolved = resolveNotionHref(href, idToSlug)
-        if (!resolved) return text
+        const notionResolved = resolveNotionHref(href, idToSlug)
+        if (!notionResolved) return text
+        const resolved = canonicaliseReplayHref(notionResolved)
 
         const isExternal = /^https?:\/\//i.test(resolved)
         const targetAttrs = isExternal ? ' target="_blank" rel="noopener noreferrer"' : ''

--- a/src/app/blog/components/BlogPostBody.tsx
+++ b/src/app/blog/components/BlogPostBody.tsx
@@ -69,7 +69,9 @@ function canonicaliseReplayHref(href: string): string {
 
   if (url.protocol !== 'http:' && url.protocol !== 'https:') return href
 
-  const host = url.hostname.toLowerCase()
+  // Strip a fully-qualified trailing dot: one post links to `http://replay.io./`,
+  // which is a valid absolute form of the same host.
+  const host = url.hostname.toLowerCase().replace(/\.$/, '')
 
   if (host === 'blog.replay.io') {
     const path = resolveBlogRedirect(url.pathname)

--- a/src/app/blog/components/BlogPostBody.tsx
+++ b/src/app/blog/components/BlogPostBody.tsx
@@ -2,6 +2,7 @@ import { Marked } from 'marked'
 import { markedHighlight } from 'marked-highlight'
 import Prism from 'prismjs'
 import { resolveBlogRedirect } from '~/lib/blog-redirect'
+import { resolveDocsHref } from '~/lib/docs-links'
 import 'prismjs/components/prism-bash'
 import 'prismjs/components/prism-css'
 import 'prismjs/components/prism-diff'
@@ -59,7 +60,7 @@ function resolveNotionHref(
  * `blog.replay.io` paths go through the same slug mapping the middleware uses to 301
  * that host, so the two cannot drift apart.
  */
-function canonicaliseReplayHref(href: string): string {
+function canonicaliseReplayHref(href: string): string | null {
   let url: URL
   try {
     url = new URL(href)
@@ -80,6 +81,11 @@ function canonicaliseReplayHref(href: string): string {
 
   if (host === 'replay.io' || host === 'www.replay.io') {
     return `https://www.replay.io${url.pathname}${url.search}${url.hash}`
+  }
+
+  if (host === 'docs.replay.io') {
+    // May return null, meaning the target is gone with no equivalent.
+    return resolveDocsHref(url)
   }
 
   return href
@@ -116,6 +122,7 @@ function createMarked(idToSlug: Record<string, string>) {
         const notionResolved = resolveNotionHref(href, idToSlug)
         if (!notionResolved) return text
         const resolved = canonicaliseReplayHref(notionResolved)
+        if (!resolved) return text
 
         const isExternal = /^https?:\/\//i.test(resolved)
         const targetAttrs = isExternal ? ' target="_blank" rel="noopener noreferrer"' : ''

--- a/src/lib/blog-metadata.ts
+++ b/src/lib/blog-metadata.ts
@@ -79,12 +79,18 @@ export function buildPostDescription(excerpt: string, markdown = '', fallback = 
 }
 
 /**
- * Append the site suffix only when the result still fits inside the title limit.
+ * Build the `<title>` for a post.
  *
- * Long post titles are the author's words, so they are left intact rather than
- * truncated; this just stops the suffix making them worse.
+ * The site suffix is appended only when the result still fits the limit; adding it
+ * unconditionally was pushing already-long titles further over.
+ *
+ * A post title that exceeds the limit on its own is cut at a word boundary. Search
+ * engines truncate these in results regardless, so this only decides where the cut
+ * lands rather than letting it fall mid-word. The visible `<h1>` and the post itself
+ * are untouched: this affects the title tag alone.
  */
 export function buildPostTitle(postTitle: string, suffix = ' — Replay Blog'): string {
   const withSuffix = `${postTitle}${suffix}`
-  return withSuffix.length <= TITLE_MAX ? withSuffix : postTitle
+  if (withSuffix.length <= TITLE_MAX) return withSuffix
+  return truncateAtWord(postTitle, TITLE_MAX)
 }

--- a/src/lib/blog-metadata.ts
+++ b/src/lib/blog-metadata.ts
@@ -1,0 +1,90 @@
+/**
+ * Helpers for deriving search-friendly metadata from Notion blog posts.
+ *
+ * Ahrefs flagged 77 posts with a meta description under 110 characters and 57 over
+ * 160, because the description comes straight from the Notion `Description` property
+ * and nothing enforces a length. Titles were flagged too: the page appended
+ * " — Replay Blog" unconditionally, which pushed already-long post titles further
+ * past the 60-character limit.
+ */
+
+const DESC_MIN = 110
+const DESC_MAX = 160
+const TITLE_MAX = 60
+
+/** Cut at a word boundary, appending an ellipsis, without exceeding `max`. */
+function truncateAtWord(value: string, max: number): string {
+  if (value.length <= max) return value
+  // Leave room for the ellipsis.
+  const slice = value.slice(0, max - 1)
+  const lastSpace = slice.lastIndexOf(' ')
+  const cut = lastSpace > max * 0.6 ? slice.slice(0, lastSpace) : slice
+  return `${cut.replace(/[\s,;:.!?-]+$/, '')}…`
+}
+
+/**
+ * Reduce Notion-generated markdown to plain prose suitable for a meta description.
+ *
+ * Drops fenced code, images, headings, block quotes, list markers and callout
+ * emoji, and unwraps links to their text. Deliberately conservative: anything it
+ * cannot confidently turn into prose is discarded rather than guessed at.
+ */
+export function markdownToPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, ' ') // fenced code
+    .replace(/`[^`]*`/g, ' ') // inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // images
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1') // links -> text
+    .replace(/^\s{0,3}#{1,6}\s+.*$/gm, ' ') // headings
+    .replace(/^\s{0,3}>\s?/gm, ' ') // block quotes
+    .replace(/^\s{0,3}([-*+]|\d+\.)\s+/gm, ' ') // list markers
+    .replace(/^\s{0,3}(\*\s*){3,}$/gm, ' ') // horizontal rules
+    .replace(/[*_~]/g, '') // emphasis
+    .replace(/<[^>]+>/g, ' ') // stray html
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/**
+ * Build a meta description that lands inside the 110-160 character band where the
+ * available text allows it.
+ *
+ * Order of preference:
+ *  1. The Notion excerpt, if it already fits.
+ *  2. The excerpt truncated, if it is too long.
+ *  3. The excerpt topped up from the post body, if it is too short.
+ *  4. The body alone, then a generic fallback.
+ *
+ * A post with very little prose can still fall short of DESC_MIN. That is correct:
+ * padding it out would mean inventing copy.
+ */
+export function buildPostDescription(excerpt: string, markdown = '', fallback = ''): string {
+  const clean = (excerpt ?? '').replace(/\s+/g, ' ').trim()
+
+  if (clean.length > DESC_MAX) return truncateAtWord(clean, DESC_MAX)
+  if (clean.length >= DESC_MIN) return clean
+
+  const body = markdownToPlainText(markdown)
+
+  if (clean && body) {
+    // Top the excerpt up with the opening of the post, avoiding an immediate repeat.
+    const rest = body.startsWith(clean) ? body.slice(clean.length).trim() : body
+    const combined = `${clean} ${rest}`.replace(/\s+/g, ' ').trim()
+    if (combined.length >= DESC_MIN) return truncateAtWord(combined, DESC_MAX)
+  }
+
+  if (body.length >= DESC_MIN) return truncateAtWord(body, DESC_MAX)
+
+  return clean || truncateAtWord(body, DESC_MAX) || fallback
+}
+
+/**
+ * Append the site suffix only when the result still fits inside the title limit.
+ *
+ * Long post titles are the author's words, so they are left intact rather than
+ * truncated; this just stops the suffix making them worse.
+ */
+export function buildPostTitle(postTitle: string, suffix = ' — Replay Blog'): string {
+  const withSuffix = `${postTitle}${suffix}`
+  return withSuffix.length <= TITLE_MAX ? withSuffix : postTitle
+}

--- a/src/lib/docs-links.ts
+++ b/src/lib/docs-links.ts
@@ -1,0 +1,95 @@
+/**
+ * Repairs links to docs.replay.io that appear in archived blog posts.
+ *
+ * This is a shim, and deliberately so. The right fix is redirects on the docs
+ * property, which would also repair external backlinks and Google's index;
+ * `docs-redirects-handoff.md` documents that ask. Until it lands, these links are
+ * either dead or take an unnecessary hop, and both are visible to crawlers.
+ *
+ * Every mapping below was verified by request against docs.replay.io: the key
+ * returns 404 (or redirects), the value returns 200. Several are corroborated by
+ * docs' own redirects, e.g. docs sends `/reference-guide/debugging/print-statements`
+ * to the same page we map `/docs/print-statements-<id>` to.
+ *
+ * Anything not listed is left untouched, including `docs.replay.io/` itself: its
+ * redirect is a 307 and the root is the canonical entry point, so pinning it to
+ * whichever page currently sits behind it would be worse than the extra hop.
+ */
+
+/** Dead or redirecting docs path -> the live page it should point at. */
+export const DOCS_PATH_REWRITES: Record<string, string> = {
+  // --- 404s: the pre-migration Notion-id scheme -------------------------------
+  '/docs/getting-started-5fc7ace7f3e449ce903e89e59d4b93ba':
+    '/basics/getting-started/record-your-app',
+  '/docs/why-replay-12b64a4c3b5d461981f1b498fc055d56': '/basics/time-travel/why-time-travel',
+  '/docs/viewer-26591deb256c473a946d0f64abb67859':
+    '/basics/replay-devtools/browser-devtools/replay-viewer',
+  '/docs/adding-source-maps-1923e679c1e4411db1bda29536eb1e31': '/reference/replay-cli/source-maps',
+  '/docs/print-statements-1dcf7c3a8414423aab122ea7c4a41661':
+    '/basics/replay-devtools/time-travel-devtools/live-console-logs',
+
+  // --- 404s: restructured paths ----------------------------------------------
+  '/reference-guide/recording/replay-node-(experimental)': '/reference/replay-runtimes/replay-node',
+  '/resources/comparisons/chrome-recorder-vs-replay': '/learn/comparisons/chrome',
+  '/recording-browser-tests-(beta)': '/basics/getting-started/record-your-playwright-tests',
+
+  // --- 3XX: resolve the hop --------------------------------------------------
+  '/test-suites': '/basics/test-suites/recent-runs',
+  '/getting-started/test-suite-integration': '/basics/test-suites/recent-runs',
+  '/getting-started/what-is-replay-io': '/basics/time-travel/why-time-travel',
+  '/getting-started/introduction-to-debugging': '/basics/time-travel/why-time-travel',
+  '/getting-started/teams-admin/setting-up-a-team': '/reference/replay-teams/setting-up-a-team',
+  '/getting-started/bug-reports/installing-the-replay-browser': '/basics/replay-qa/overview',
+  '/learn-more/workflows/oss-projects': '/reference/test-runners/overview',
+  '/reference-guide/debugging/focus-mode':
+    '/basics/replay-devtools/time-travel-devtools/focus-window',
+  '/reference-guide/debugging/jumping': '/basics/replay-devtools/time-travel-devtools/jump-to-event',
+  '/reference-guide/debugging/print-statements':
+    '/basics/replay-devtools/time-travel-devtools/live-console-logs',
+  '/reference-guide/dev-tools/console': '/basics/replay-devtools/browser-devtools/console',
+  '/reference-guide/viewer': '/basics/replay-devtools/browser-devtools/replay-viewer',
+
+  // docs currently 308s this source-maps page to the Redux panel, which is simply
+  // the wrong destination for the link text. Point it at the real source maps page
+  // instead of following a redirect we can see is broken.
+  '/learn-more/contribute/how-replay-works/our-approach-for-source-maps':
+    '/reference/replay-cli/source-maps'
+}
+
+/**
+ * Dead docs paths with no live equivalent.
+ *
+ * Links to these render as plain text rather than anchors, the same treatment given
+ * to Notion links whose destination did not survive migration. Sending a reader to a
+ * loosely related page would be worse than not linking: `/learn/comparisons/devtools`
+ * is about Browser DevTools, not Cypress, and there is no comparisons index to fall
+ * back on.
+ */
+export const DOCS_PATHS_WITHOUT_EQUIVALENT = new Set([
+  '/docs/contributing-to-replay-711d4d8b10fb497aba2a7c06583b26a6',
+  '/docs/debugging-a-replay-1c18f02c9f1d455188e3f202ef5f5c08',
+  '/resources/comparisons/cypress-test-replay-vs-replay-devtools',
+  '/resources/comparisons/session-replay-vs-runtime-replay',
+  '/resources/get-help/troubleshooting/importing-ssl-certificate'
+])
+
+/**
+ * Resolve a docs.replay.io URL.
+ *
+ * Returns the rewritten URL, `null` if the link should be dropped, or the original
+ * string when we have nothing to say about it.
+ *
+ * Query strings are preserved so utm tags survive. Fragments are not: they are Notion
+ * block ids or headings from the old page, and carrying them onto a different page
+ * would point at an anchor that does not exist.
+ */
+export function resolveDocsHref(url: URL): string | null {
+  const path = url.pathname.replace(/\/$/, '') || '/'
+
+  if (DOCS_PATHS_WITHOUT_EQUIVALENT.has(path)) return null
+
+  const replacement = DOCS_PATH_REWRITES[path]
+  if (!replacement) return url.toString()
+
+  return `https://docs.replay.io${replacement}${url.search}`
+}

--- a/src/lib/notion-blog.ts
+++ b/src/lib/notion-blog.ts
@@ -300,7 +300,7 @@ export const getNotionIdToSlugMap = async (): Promise<Record<string, string>> =>
   return map
 }
 
-export const getBlogPostBySlug = async (
+const loadBlogPostBySlug = async (
   slug: string
 ): Promise<{ post: BlogPost; markdown: string } | null> => {
   if (!hasNotionConfig() || !n2m) return null
@@ -320,4 +320,36 @@ export const getBlogPostBySlug = async (
     console.error(`[notion-blog] Failed to fetch markdown for slug "${slug}":`, error)
     return null
   }
+}
+
+/**
+ * Every route calls this twice: once from `generateMetadata` and once from the page
+ * itself. `pageToMarkdown` walks the page block by block, so each uncached call is
+ * many Notion requests, and at 161 posts that doubling was enough to get the build
+ * rate limited. A prerender then sat in `withNotionRetry`'s backoff until it blew
+ * past Next's static generation timeout and failed the deploy.
+ *
+ * Caching per slug collapses the pair back to one fetch. React's `cache()` would be
+ * the idiomatic way to dedupe between generateMetadata and the page, but this repo is
+ * on React 18.2, which does not export it.
+ *
+ * The revalidate window matches the posts list deliberately: markdown embeds the same
+ * ~1h presigned S3 image URLs, so it must not be held longer than that cache is.
+ */
+const cachedLoadBlogPostBySlug = (slug: string) =>
+  unstable_cache(() => loadBlogPostBySlug(slug), [NOTION_BLOG_POSTS_TAG, 'post', slug], {
+    tags: [NOTION_BLOG_POSTS_TAG],
+    revalidate: NOTION_BLOG_POSTS_REVALIDATE_SECONDS
+  })()
+
+export const getBlogPostBySlug = async (
+  slug: string
+): Promise<{ post: BlogPost; markdown: string } | null> => {
+  if (!hasNotionConfig() || !n2m) return null
+
+  if (process.env.NODE_ENV !== 'production') {
+    return loadBlogPostBySlug(slug)
+  }
+
+  return cachedLoadBlogPostBySlug(slug)
 }

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -275,6 +275,41 @@ test.describe('blog', () => {
       []
     )
   })
+
+  test('no post links to our own site over http, the apex domain or blog.replay.io', async ({
+    request
+  }) => {
+    test.setTimeout(5 * 60 * 1000)
+
+    const xml = await (await request.get(`${BASE}/sitemap.xml`)).text()
+    const posts = [...xml.matchAll(/<loc>([^<]*\/blog\/[^<]+)<\/loc>/g)]
+      .map((m) => m[1])
+      .filter((u) => !u.endsWith('/blog/archive'))
+
+    if (posts.length === 0) {
+      // eslint-disable-next-line no-console
+      console.log('note: no blog posts available (NOTION_TOKEN unset); skipping')
+      return
+    }
+
+    // Each of these redirects, and the http ones count as an HTTPS page linking to
+    // HTTP, which Ahrefs reports as an error rather than a warning. Sibling subdomains
+    // (docs, app, static) are separate properties and must not be rewritten, so they
+    // are deliberately absent from this pattern.
+    const NON_CANONICAL = /href="(http:\/\/(?:www\.)?replay\.io[^"]*|https?:\/\/replay\.io[^"]*|https?:\/\/blog\.replay\.io[^"]*)"/gi
+
+    const offenders: string[] = []
+    for (const url of posts) {
+      const html = await (await request.get(url)).text()
+      const hits = html.match(NON_CANONICAL)
+      if (hits) offenders.push(`${new URL(url).pathname} -> ${[...new Set(hits)].join(' ')}`)
+    }
+
+    expect(
+      offenders,
+      `posts linking to a non-canonical Replay URL:\n${offenders.join('\n')}`
+    ).toEqual([])
+  })
 })
 
 test.describe('internal links', () => {

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -247,7 +247,11 @@ test.describe('blog', () => {
     test.setTimeout(5 * 60 * 1000)
 
     const xml = await (await request.get(`${BASE}/sitemap.xml`)).text()
-    const posts = [...xml.matchAll(/<loc>([^<]*\/blog\/[^<]+)<\/loc>/g)].map((m) => m[1])
+    // The sitemap advertises absolute production URLs. Keep only the path, so this
+    // scans the deployment under test rather than always hitting www.replay.io.
+    const posts = [...xml.matchAll(/<loc>([^<]*\/blog\/[^<]+)<\/loc>/g)].map(
+      (m) => new URL(m[1]).pathname
+    )
 
     if (posts.length === 0) {
       // eslint-disable-next-line no-console
@@ -265,10 +269,10 @@ test.describe('blog', () => {
     const BARE_ID_HREF = /href="\/[0-9a-f]{32}(?:[?#][^"]*)?"/gi
 
     const offenders: string[] = []
-    for (const url of posts) {
-      const html = await (await request.get(url)).text()
+    for (const path of posts) {
+      const html = await (await request.get(`${BASE}${path}`)).text()
       const hits = html.match(BARE_ID_HREF)
-      if (hits) offenders.push(`${new URL(url).pathname} -> ${[...new Set(hits)].join(' ')}`)
+      if (hits) offenders.push(`${path} -> ${[...new Set(hits)].join(' ')}`)
     }
 
     expect(offenders, `posts still linking to a bare Notion id:\n${offenders.join('\n')}`).toEqual(
@@ -282,9 +286,10 @@ test.describe('blog', () => {
     test.setTimeout(5 * 60 * 1000)
 
     const xml = await (await request.get(`${BASE}/sitemap.xml`)).text()
+    // Paths only: see the note above about the sitemap carrying production URLs.
     const posts = [...xml.matchAll(/<loc>([^<]*\/blog\/[^<]+)<\/loc>/g)]
-      .map((m) => m[1])
-      .filter((u) => !u.endsWith('/blog/archive'))
+      .map((m) => new URL(m[1]).pathname)
+      .filter((p) => p !== '/blog/archive')
 
     if (posts.length === 0) {
       // eslint-disable-next-line no-console
@@ -299,10 +304,10 @@ test.describe('blog', () => {
     const NON_CANONICAL = /href="(http:\/\/(?:www\.)?replay\.io[^"]*|https?:\/\/replay\.io[^"]*|https?:\/\/blog\.replay\.io[^"]*)"/gi
 
     const offenders: string[] = []
-    for (const url of posts) {
-      const html = await (await request.get(url)).text()
+    for (const path of posts) {
+      const html = await (await request.get(`${BASE}${path}`)).text()
       const hits = html.match(NON_CANONICAL)
-      if (hits) offenders.push(`${new URL(url).pathname} -> ${[...new Set(hits)].join(' ')}`)
+      if (hits) offenders.push(`${path} -> ${[...new Set(hits)].join(' ')}`)
     }
 
     expect(

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -198,6 +198,9 @@ test.describe('sitemap', () => {
   })
 
   test('every listed URL resolves 200 without redirecting', async ({ request }) => {
+    // Production advertises ~175 URLs and these are checked one at a time, which
+    // overruns the 30s default when run against a deployment rather than localhost.
+    test.setTimeout(5 * 60 * 1000)
     const res = await request.get(`${BASE}/sitemap.xml`)
     const xml = await res.text()
     const urls = [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1])
@@ -319,6 +322,9 @@ test.describe('blog', () => {
 
 test.describe('internal links', () => {
   test('no page links to a path that does not exist', async ({ request }) => {
+    // Crawls every route and then every distinct internal link it finds; too slow
+    // for the 30s default against a real deployment.
+    test.setTimeout(5 * 60 * 1000)
     const seen = new Set<string>()
 
     for (const route of ROUTES) {


### PR DESCRIPTION
From the Ahrefs crawl of 4 Aug 17:05, and then everything else that was fixable.

## Verified on the preview, across all 161 posts

| | Before | After |
| --- | --- | --- |
| Meta descriptions out of band | 134 | **2** |
| — too long | 57 | **0** |
| — too short | 77 | **2** |
| Titles over 60 chars | 15 | **0** |
| Bare Notion id links | 5 | **0** |
| Non-canonical Replay links | many | **0** |
| Dead docs.replay.io links | 13 | **0** |
| Redirecting docs.replay.io links | 15 | **0** |

The full suite (45 tests) passes against a preview carrying all 161 posts.

## Links to our own site

Posts link to `http://replay.io`, the apex domain and the retired
`blog.replay.io`. All redirect; the http ones count as an HTTPS page linking to
HTTP, which is an error. All now rewrite to canonical `https://www.replay.io`.
`blog.replay.io` paths reuse `resolveBlogRedirect`, the same slug map the
middleware uses, so the two cannot drift.

One post links to `http://replay.io./` with a fully-qualified trailing dot;
hostnames are compared with that stripped.

## Links to docs.replay.io

Scanning the live blog found more than the Ahrefs extract listed: **40 distinct
docs links, 13 dead and 15 redirecting**.

`src/lib/docs-links.ts` maps 21 paths to live pages and lists 5 with no
equivalent, whose links render as plain text. Every key was confirmed genuinely
dead or redirecting; all 15 distinct targets confirmed 200. Several mappings are
corroborated by docs' own redirects.

Two deliberate exceptions:

- **`docs.replay.io/` is left alone.** Its redirect is a 307 and the root is the
  canonical entry point, so pinning it to whichever page sits behind it today
  would be worse than the extra hop.
- **`app.replay.io` is untouched throughout.** Its redirect goes to
  `/login?returnTo=`, which is per-visitor; rewriting it would send signed-in
  users to a login page.

One redirect is deliberately **not** followed: docs 308s its source-maps page to
the Redux panel, which is the wrong destination for the link text, so that maps
to the real source maps page. Flagged in the handoff doc.

**This is a shim.** Redirects on the docs property remain the right fix, would
also repair external backlinks and Google's index, and would let
`src/lib/docs-links.ts` be deleted.

## Descriptions and titles

Descriptions come from Notion with nothing enforcing a length: too long are
trimmed at a word boundary, too short topped up from the post's opening prose.
The 2 that remain short are correct — one post has 46 characters of prose in
total, and padding it would mean inventing copy.

Titles are cut at a word boundary in the `<title>` tag only; the visible `<h1>`
and the post are untouched.

## The build failure this branch hit first

The deploy failed with Notion rate limiting and a static generation timeout.
`getBlogPostBySlug` was called twice per route, once from `generateMetadata` and
once from the page, and was never memoised. Caching per slug halves Notion
traffic during a build. `staticPageGenerationTimeout` is raised to 180s so one
slow post cannot fail a deploy. Pre-existing, but it is what made these builds
fragile.

## Two test bugs fixed on the way

- The blog scans took URLs straight from the sitemap, which advertises absolute
  production URLs, so they always hit www.replay.io regardless of `BASE_URL`.
  Running them against a preview silently reported production's state.
- The sitemap and internal-link crawls walk ~175 URLs and overran Playwright's
  30s default against a deployment, reading as a site failure rather than a
  harness one.

## What remains, and why

- **`docs.replay.io/` (3 links)** — deliberate, see above.
- **`app.replay.io` links** — deliberate, auth-dependent.
- **2 short descriptions** — those posts have almost no prose.
- **10 posts with titles under 30 chars** — pre-existing and identical on
  production ("Nut.new", "Replay QA"). Ahrefs has never flagged them; our test
  floor is simply stricter.
